### PR TITLE
Sync Iris and Extensions version

### DIFF
--- a/config/import.plugin.js
+++ b/config/import.plugin.js
@@ -8,11 +8,12 @@ const constants = require("./constants");
 const extensionsKey = constants.extensionsKey;
 
 function ImportPlugin(options) {
-    // get the info i need
+    // get latest version tag
     const latestCompatibleVersionTag = require('child_process')
         .execSync('git describe --abbrev=0 --tags')
         .toString();
 
+    // get all version tags for the commit specified by the latest tag
     let compatibleVersionsTags = [];
     if (!latestCompatibleVersionTag.includes('fatal: Not a git repository') && !latestCompatibleVersionTag.includes('is not recognized as an internal or external command')) {
         compatibleVersionsTags = require('child_process')


### PR DESCRIPTION
Implemented a mechanism to get the latest version tags from the currently checked out branch/commit and pass them to Iris.