### PR TITLE
Refactoring extensions E2E tests

### DIFF
--- a/tests/e2e/app-elements/editor-popup.map.ts
+++ b/tests/e2e/app-elements/editor-popup.map.ts
@@ -1,6 +1,6 @@
 import { element, by, ElementFinder } from "protractor";
 
 export class EditorPopupMap {
-    public static ToolPopup: ElementFinder = element(by.css(".k-ct-popup.symbol-popup.k-popup"));
+    public static ToolPopup: ElementFinder = element(by.css(".k-ct-popup.symbol-popup"));
     public static SymbolCell: ElementFinder = element(by.css(".symbol-cell"));
 }

--- a/tests/e2e/app-elements/item-details.component.ts
+++ b/tests/e2e/app-elements/item-details.component.ts
@@ -16,16 +16,16 @@ export class ItemDetails {
     }
 
     static async ClickHtmlToolbarSitefinityVideos(): Promise<void> {
-        const wordCountButtonClass = "k-i-Sitefinity-videos";
-        await BrowserWaitForElement(ItemDetailsMap.ToolbarButton(wordCountButtonClass));
-        const toolbarButton = ItemDetailsMap.ToolbarButton(wordCountButtonClass);
+        const videosButtonTitle = "Sitefinity videos";
+        await BrowserWaitForElement(ItemDetailsMap.ToolbarButtonByTitle(videosButtonTitle));
+        const toolbarButton = ItemDetailsMap.ToolbarButtonByTitle(videosButtonTitle);
         await toolbarButton.click();
     }
 
     static async ExpandHtmlField(): Promise<void>  {
-        await BrowserWaitForElement(ItemDetailsMap.HtmlFieldExpander);
-        const htmlField = ItemDetailsMap.HtmlFieldExpander;
-        await htmlField.click();
+        await BrowserWaitForElement(ItemDetailsMap.HtmlFieldExpandButton);
+        const htmlFieldExpandButton = ItemDetailsMap.HtmlFieldExpandButton;
+        await htmlFieldExpandButton.click();
     }
 
     static async VerifyCustomTitleField(): Promise<void> {
@@ -43,11 +43,17 @@ export class ItemDetails {
         }
     }
 
-    static async VerifyAndClickSymbolListButton(): Promise<void> {
-        const symbolListButtonClass = "k-i-insertsymbol";
-        await BrowserWaitForElement(ItemDetailsMap.ToolbarButton(symbolListButtonClass));
-        const toolbarButton = ItemDetailsMap.ToolbarButton(symbolListButtonClass);
+    static async ClickToolbarButtonByTitle(buttonTitle: string): Promise<void> {
+        await BrowserWaitForElement(ItemDetailsMap.ToolbarButtonByTitle(buttonTitle));
+        const toolbarButton = ItemDetailsMap.ToolbarButtonByTitle(buttonTitle);
         await toolbarButton.click();
+    }
+
+    static async VerifyAndClickSymbolListButton(): Promise<void> {
+        // const symbolListButtonClass = "k-i-insertsymbol";
+        // await BrowserWaitForElement(ItemDetailsMap.ToolbarButton(symbolListButtonClass));
+        // const toolbarButton = ItemDetailsMap.ToolbarButton(symbolListButtonClass);
+        // await toolbarButton.click();
         await BrowserWaitForElement(EditorPopupMap.ToolPopup);
         const symbolButton = EditorPopupMap.SymbolCell;
         const editor = ItemDetailsMap.EditorInternalField;

--- a/tests/e2e/app-elements/item-details.component.ts
+++ b/tests/e2e/app-elements/item-details.component.ts
@@ -7,19 +7,8 @@ import { ItemListMap } from "./item-list.map";
 
 export class ItemDetails {
     static async VerifyHtmlToolbarWordCount(expectedContent: string): Promise<void> {
-        const wordCountButtonClass = "k-i-Words-count";
-        await BrowserWaitForElement(ItemDetailsMap.ToolbarButton(wordCountButtonClass));
-        const toolbarButton = ItemDetailsMap.ToolbarButton(wordCountButtonClass);
-        await toolbarButton.click();
         const expectedCount = expectedContent.split(" ").length;
         await BrowserVerifyAlert(`Words count: ${expectedCount}`);
-    }
-
-    static async ClickHtmlToolbarSitefinityVideos(): Promise<void> {
-        const videosButtonTitle = "Sitefinity videos";
-        await BrowserWaitForElement(ItemDetailsMap.ToolbarButtonByTitle(videosButtonTitle));
-        const toolbarButton = ItemDetailsMap.ToolbarButtonByTitle(videosButtonTitle);
-        await toolbarButton.click();
     }
 
     static async ExpandHtmlField(): Promise<void>  {
@@ -29,7 +18,7 @@ export class ItemDetails {
     }
 
     static async VerifyCustomTitleField(): Promise<void> {
-        await BrowserWaitForElement(ItemDetailsMap.TitleField);
+        await BrowserWaitForElement(ItemDetailsMap.ExtendedTitleField);
         expect(await ItemDetailsMap.ExtendedTitleField.isPresent()).toBeTruthy("The title field extension class was not found");
     }
 
@@ -50,21 +39,19 @@ export class ItemDetails {
     }
 
     static async VerifyAndClickSymbolListButton(): Promise<void> {
-        // const symbolListButtonClass = "k-i-insertsymbol";
-        // await BrowserWaitForElement(ItemDetailsMap.ToolbarButton(symbolListButtonClass));
-        // const toolbarButton = ItemDetailsMap.ToolbarButton(symbolListButtonClass);
-        // await toolbarButton.click();
         await BrowserWaitForElement(EditorPopupMap.ToolPopup);
-        const symbolButton = EditorPopupMap.SymbolCell;
         const editor = ItemDetailsMap.EditorInternalField;
+        const contentsBeforeInsert = await editor.getText();
 
-        const contents = await editor.getText();
+        const symbolButton = EditorPopupMap.SymbolCell;
         await symbolButton.click();
+        
         const contentAfterInsert = await editor.getText();
+
         // should hide the popup when symbol is clicked
         await BrowserWaitForElementHidden(EditorPopupMap.ToolPopup);
 
         // should have one more character after the symbol is inserted
-        expect(contents.length).toBe(contentAfterInsert.length - 1);
+        expect(contentAfterInsert.length).toBe(contentsBeforeInsert.length + 1);
     }
 }

--- a/tests/e2e/app-elements/item-details.map.ts
+++ b/tests/e2e/app-elements/item-details.map.ts
@@ -1,18 +1,9 @@
 import { element, by, ElementFinder } from "protractor";
 
-const defaultFieldLocator = ".sf-input.-rich-text";
-const itemTitleExtensionCssClass = ".custom-title-input";
-
 export class ItemDetailsMap {
-    public static TitleField: ElementFinder = element(by.css(defaultFieldLocator));
-    public static ExtendedTitleField: ElementFinder = element(by.css(itemTitleExtensionCssClass));
-    public static HtmlField: ElementFinder = element(by.css(".sf-input.-rich-text"));
+    public static ExtendedTitleField: ElementFinder = element(by.css(".custom-title-input"));
     public static EditorInternalField: ElementFinder = element(by.cssContainingText("div", "Hello everyone"));
     public static HtmlFieldExpandButton: ElementFinder = element(by.css("a[title=Expand]"));
-
-    public static ToolbarButton(customClass: string): ElementFinder {
-        return element(by.className(customClass));
-    }
 
     public static ToolbarButtonByTitle(buttonTitle: string): ElementFinder {
         return element(by.css(`a[Title="${buttonTitle}"]`))

--- a/tests/e2e/app-elements/item-details.map.ts
+++ b/tests/e2e/app-elements/item-details.map.ts
@@ -6,11 +6,15 @@ const itemTitleExtensionCssClass = ".custom-title-input";
 export class ItemDetailsMap {
     public static TitleField: ElementFinder = element(by.css(defaultFieldLocator));
     public static ExtendedTitleField: ElementFinder = element(by.css(itemTitleExtensionCssClass));
-    public static HtmlFieldExpander: ElementFinder = element(by.css(".sf-expand-button"));
-    public static EditorInternalField: ElementFinder = element(by.css(".k-editor.k-editor-inline"));
-    public static PublishButton: ElementFinder = element(by.cssContainingText("button", "Publish"));
+    public static HtmlField: ElementFinder = element(by.css(".sf-input.-rich-text"));
+    public static EditorInternalField: ElementFinder = element(by.cssContainingText("div", "Hello everyone"));
+    public static HtmlFieldExpandButton: ElementFinder = element(by.css("a[title=Expand]"));
 
     public static ToolbarButton(customClass: string): ElementFinder {
         return element(by.className(customClass));
+    }
+
+    public static ToolbarButtonByTitle(buttonTitle: string): ElementFinder {
+        return element(by.css(`a[Title="${buttonTitle}"]`))
     }
 }

--- a/tests/e2e/app-elements/item-list.component.ts
+++ b/tests/e2e/app-elements/item-list.component.ts
@@ -16,6 +16,10 @@ export class ItemList {
         expect(await ItemListMap.TitleTag.getText()).toBe(itemTitlePlural);
     }
 
+    static async VerifyImageColumn() {
+        await BrowserWaitForElement(ItemListMap.ImageColumn);
+    }
+
     static async VerifyBasicGridElements(itemTitle: string, headers: string[], allItems: number, currentLoadedItems = DEFAULT_ITEMS_NUMBER) {
         await BrowserWaitForElement(ItemListMap.TitleTag);
         await ItemList.VerifyHeaders(headers);
@@ -33,8 +37,8 @@ export class ItemList {
         expect(await ItemListMap.CountLabel.getText()).toBe(expectedItemCountLabel);
     }
 
-    static async ClickPrintPreview(title: string) {
-        const actionButton = ItemListMap.GetItemActionsMenu(title);
+    static async ClickPrintPreview() {
+        const actionButton = ItemListMap.GetItemActionsMenu();
 
         await actionButton.click();
         await BrowserWaitForElement(ItemListMap.PrintPreviewButton);
@@ -42,7 +46,6 @@ export class ItemList {
     }
 
     static async ClickOnItem(title: string) {
-        await BrowserWaitForElement(ItemListMap.CountLabel);
         await BrowserWaitForElement(ItemListMap.GetRowTitleCell(title));
         const item = ItemListMap.GetRowTitleCell(title);
         await item.click();

--- a/tests/e2e/app-elements/item-list.component.ts
+++ b/tests/e2e/app-elements/item-list.component.ts
@@ -1,45 +1,15 @@
 require("jasmine-expect");
 
-import { removeQueryParams } from "../helpers/common";
 import { ItemListMap } from "./item-list.map";
-import { BrowserWaitForElement, BrowserGetUrl } from "../helpers/browser-helpers";
-import { CONTENT_PAGE_URL, DEFAULT_ITEMS_NUMBER } from "../helpers/constants";
+import { BrowserWaitForElement } from "../helpers/browser-helpers";
 
 export class ItemList {
-
-    static async VerifyBasicUIElements(typeName: string, itemTitlePlural: string) {
-        await BrowserWaitForElement(ItemListMap.CountLabel);
-        const trimmedUrl = await removeQueryParams(BrowserGetUrl());
-        const expectedUrl = CONTENT_PAGE_URL + typeName.toLowerCase();
-        expect(trimmedUrl).toBe(expectedUrl);
-        expect(await ItemListMap.TitleTag.isDisplayed()).toBeTruthy();
-        expect(await ItemListMap.TitleTag.getText()).toBe(itemTitlePlural);
-    }
-
     static async VerifyImageColumn() {
         await BrowserWaitForElement(ItemListMap.ImageColumn);
     }
 
-    static async VerifyBasicGridElements(itemTitle: string, headers: string[], allItems: number, currentLoadedItems = DEFAULT_ITEMS_NUMBER) {
-        await BrowserWaitForElement(ItemListMap.TitleTag);
-        await ItemList.VerifyHeaders(headers);
-        expect(await ItemListMap.CountLabel.isDisplayed()).toBeTruthy();
-        expect(await ItemListMap.TableElements.count()).toBe(currentLoadedItems);
-
-        let expectedItemCountLabel: string;
-        if (allItems <= currentLoadedItems) {
-            expectedItemCountLabel = allItems + " " + itemTitle.toLowerCase();
-        } else {
-            expectedItemCountLabel = DEFAULT_ITEMS_NUMBER + " from " + allItems + " " + itemTitle.toLowerCase();
-        }
-        expectedItemCountLabel = (allItems > 1) ? `${expectedItemCountLabel}` : expectedItemCountLabel;
-
-        expect(await ItemListMap.CountLabel.getText()).toBe(expectedItemCountLabel);
-    }
-
     static async ClickPrintPreview() {
         const actionButton = ItemListMap.GetItemActionsMenu();
-
         await actionButton.click();
         await BrowserWaitForElement(ItemListMap.PrintPreviewButton);
         await ItemListMap.PrintPreviewButton.click();
@@ -49,18 +19,5 @@ export class ItemList {
         await BrowserWaitForElement(ItemListMap.GetRowTitleCell(title));
         const item = ItemListMap.GetRowTitleCell(title);
         await item.click();
-    }
-
-    private static async VerifyHeaders(headers: string[]) {
-        const headersNumber = headers.length;
-        try {
-            expect(await ItemListMap.TableHeaders.count()).toBe(headersNumber);
-            for (let i = 0; i < headersNumber; i++) {
-                const innerText = await ItemListMap.TableHeaders.get(i).getAttribute("innerText");
-                expect(innerText.toUpperCase().trim()).toBe(headers[i].toUpperCase());
-            }
-        } catch (e) {
-            throw new Error("Table headers are not correct.");
-        }
     }
 }

--- a/tests/e2e/app-elements/item-list.map.ts
+++ b/tests/e2e/app-elements/item-list.map.ts
@@ -1,24 +1,30 @@
 import { element, by, ElementFinder, ElementArrayFinder } from "protractor";
 
 export class ItemListMap {
+
+    private static ImageColumnHeader = "Image";
+    private static ColumnName: string = "image3";
     public static TitleTag: ElementFinder = element.all(by.css(".sf-row h1")).last();
     public static PrintPreviewButton: ElementFinder = element(by.cssContainingText("div[role=option]", "Print preview"));
-    public static CountLabel: ElementFinder = element(by.css("div.row__col.-txt-align-right.-txt-hint"));
+    public static CustomActionsSection: ElementFinder = element(by.cssContainingText("div", "Custom commands"));
+    public static CountLabel: ElementFinder = element(by.css("div.sf-row__col.-sf-txt-align-right.-sf-txt-hint"));
     public static TableHeaders: ElementArrayFinder = element(by.className("sf-tree-list__row -head")).all(by.className("sf-tree-list__cell -head"));
     public static TableElements: ElementArrayFinder = element.all(by.css(".sf-tree-list__row:not(.-head):not(.-loading)"));
     public static BackButton: ElementFinder = element(by.css(".sf-button.-toggle.-icon[title=Back]"));
+    public static ImageColumn: ElementFinder = element(by.cssContainingText(`div[data-sftest=${ItemListMap.ColumnName}]`, ItemListMap.ImageColumnHeader));
+    public static ActionsButton: ElementFinder = element(by.css("[title=Actions]"));
 
     public static GetRowTitleCell(rowTitle: string): ElementFinder {
-        const itemRow = ItemListMap.GetTableRow(rowTitle);
-        return itemRow.element(by.css(".sf-tree-list__cell.-title"));
+        return element(by.cssContainingText("p", rowTitle));
     }
 
-    public static GetItemActionsMenu(rowTitle: string): ElementFinder {
-        const itemRow = ItemListMap.GetTableRow(rowTitle);
-        return itemRow.element(by.css("[title=Actions]"));
+    public static GetItemActionsMenu(): ElementFinder {
+        // const itemRow = ItemListMap.GetTableRow(rowTitle);
+        // return itemRow.element(by.css("[title=Actions]"));
+        return this.ActionsButton;
     }
 
-    private static GetTableRow(rowTitle: string): ElementFinder {
-        return element(by.cssContainingText(".tree-node-level-1", rowTitle));
-    }
+    // private static GetTableRow(rowTitle: string): ElementFinder {
+    //     return element(by.cssContainingText(".tree-node-level-1", rowTitle));
+    // }
 }

--- a/tests/e2e/app-elements/item-list.map.ts
+++ b/tests/e2e/app-elements/item-list.map.ts
@@ -1,30 +1,16 @@
-import { element, by, ElementFinder, ElementArrayFinder } from "protractor";
+import { element, by, ElementFinder } from "protractor";
 
 export class ItemListMap {
-
-    private static ImageColumnHeader = "Image";
-    private static ColumnName: string = "image3";
-    public static TitleTag: ElementFinder = element.all(by.css(".sf-row h1")).last();
     public static PrintPreviewButton: ElementFinder = element(by.cssContainingText("div[role=option]", "Print preview"));
-    public static CustomActionsSection: ElementFinder = element(by.cssContainingText("div", "Custom commands"));
-    public static CountLabel: ElementFinder = element(by.css("div.sf-row__col.-sf-txt-align-right.-sf-txt-hint"));
-    public static TableHeaders: ElementArrayFinder = element(by.className("sf-tree-list__row -head")).all(by.className("sf-tree-list__cell -head"));
-    public static TableElements: ElementArrayFinder = element.all(by.css(".sf-tree-list__row:not(.-head):not(.-loading)"));
-    public static BackButton: ElementFinder = element(by.css(".sf-button.-toggle.-icon[title=Back]"));
-    public static ImageColumn: ElementFinder = element(by.cssContainingText(`div[data-sftest=${ItemListMap.ColumnName}]`, ItemListMap.ImageColumnHeader));
+    public static ImageColumn: ElementFinder = element(by.cssContainingText(`div[data-sftest=image3]`, "Image"));
     public static ActionsButton: ElementFinder = element(by.css("[title=Actions]"));
+    public static BackButton: ElementFinder = element(by.css("button[title=Back]"));
 
     public static GetRowTitleCell(rowTitle: string): ElementFinder {
         return element(by.cssContainingText("p", rowTitle));
     }
 
     public static GetItemActionsMenu(): ElementFinder {
-        // const itemRow = ItemListMap.GetTableRow(rowTitle);
-        // return itemRow.element(by.css("[title=Actions]"));
         return this.ActionsButton;
     }
-
-    // private static GetTableRow(rowTitle: string): ElementFinder {
-    //     return element(by.cssContainingText(".tree-node-level-1", rowTitle));
-    // }
 }

--- a/tests/e2e/app-specs/verify-extensions.e2e-spec.ts
+++ b/tests/e2e/app-specs/verify-extensions.e2e-spec.ts
@@ -9,8 +9,6 @@ import { ItemListMap } from "../app-elements/item-list.map";
 import { ItemDetailsMap } from "../app-elements/item-details.map";
 
 describe("Verify extensions", () => {
-    const typeToTest = "News";
-    const imageColumnHeader = "IMAGE";
     const itemToVerify = "Building an Appointment Tracking App by using Telerik’s WP Cloud Components - Part 1";
 
     beforeAll(async (done: DoneFn) => {
@@ -20,14 +18,11 @@ describe("Verify extensions", () => {
 
     it("images column", async () => {
         await BrowserNavigate(CONTENT_NEWS_URL);
-        await ItemList.VerifyBasicUIElements(NEWS_TYPE_NAME, typeToTest);
-
-        const extensionHeaders = DYNAMIC_ITEM_HEADERS.map((header) => { return header === TABLE_HEADERS_CONSTANTS.DATE_CREATED ? imageColumnHeader : header; });
-        await ItemList.VerifyBasicGridElements(typeToTest, extensionHeaders, 34);
+        await ItemList.VerifyImageColumn();
     });
 
-    it("print preview ", async () => {
-        await ItemList.ClickPrintPreview(itemToVerify);
+    it("print preview", async () => {
+        await ItemList.ClickPrintPreview();
         await PrintPreview.VerifyPrintPreview(itemToVerify);
     });
 
@@ -55,13 +50,13 @@ describe("Verify extensions", () => {
         await BrowserNavigate(CONTENT_NEWS_URL);
         await ItemList.ClickOnItem(itemToVerify);
         await ItemDetails.ExpandHtmlField();
+        await ItemDetails.ClickToolbarButtonByTitle("Insert symbol");
         await ItemDetails.VerifyAndClickSymbolListButton();
     });
 
     it("item hooks", async () => {
         await BrowserNavigate(CONTENT_NEWS_URL);
         await ItemList.ClickOnItem(itemToVerify);
-        await BrowserWaitForElement(ItemDetailsMap.PublishButton);
         await BrowserVerifyConsoleOutput(itemToVerify);
     });
 });

--- a/tests/e2e/app-specs/verify-extensions.e2e-spec.ts
+++ b/tests/e2e/app-specs/verify-extensions.e2e-spec.ts
@@ -1,12 +1,11 @@
 import { initAuth } from "../helpers/authentication-manager";
 import { ItemList } from "../app-elements/item-list.component";
-import { USERNAME, PASSWORD, TIMEOUT, DYNAMIC_ITEM_HEADERS, TABLE_HEADERS_CONSTANTS, CONTENT_NEWS_URL, NEWS_TYPE_NAME, SAMPLE_TEXT_CONTENT } from "../helpers/constants";
-import { BrowserNavigate, BrowserWaitForElement, SelectAllAndPasteText, BrowserVerifyConsoleOutput } from "../helpers/browser-helpers";
+import { USERNAME, PASSWORD, TIMEOUT, CONTENT_NEWS_URL, SAMPLE_TEXT_CONTENT } from "../helpers/constants";
+import { BrowserNavigate, SelectAllAndPasteText, BrowserVerifyConsoleOutput, BrowserWaitForElement } from "../helpers/browser-helpers";
 import { PrintPreview } from "../app-elements/print-preview.component";
 import { ItemDetails } from "../app-elements/item-details.component";
 import { VideosModal } from "../app-elements/videos-modal.component";
-import { ItemListMap } from "../app-elements/item-list.map";
-import { ItemDetailsMap } from "../app-elements/item-details.map";
+import { ItemListMap } from '../app-elements/item-list.map';
 
 describe("Verify extensions", () => {
     const itemToVerify = "Building an Appointment Tracking App by using Telerik’s WP Cloud Components - Part 1";
@@ -26,24 +25,25 @@ describe("Verify extensions", () => {
         await PrintPreview.VerifyPrintPreview(itemToVerify);
     });
 
-    it("custom title field ", async () => {
+    it("custom title field", async () => {
         await BrowserNavigate(CONTENT_NEWS_URL);
         await ItemList.ClickOnItem(itemToVerify);
         await ItemDetails.VerifyCustomTitleField();
     });
 
-    it("word count editor toolbar button ", async () => {
+    it("word count editor toolbar button", async () => {
         await ItemDetails.ExpandHtmlField();
         await SelectAllAndPasteText(SAMPLE_TEXT_CONTENT);
+        await ItemDetails.ClickToolbarButtonByTitle("Words count");
         await ItemDetails.VerifyHtmlToolbarWordCount(SAMPLE_TEXT_CONTENT);
     });
 
-    it("word count editor toolbar button ", async () => {
-        await ItemDetails.ClickHtmlToolbarSitefinityVideos();
+    it("embed video editor toolbar button", async () => {
+        await ItemDetails.ClickToolbarButtonByTitle("Sitefinity videos");
         await VideosModal.VerifyModalTitle();
         await VideosModal.CancelModal();
         await ItemDetails.ClickBackButton(true);
-        await BrowserWaitForElement(ItemListMap.CountLabel);
+        await BrowserWaitForElement(ItemListMap.ImageColumn);
     });
 
     it("insert symbol", async () => {


### PR DESCRIPTION
The e2e tests here should not be broken by changes in Iris. I have tried to remove all locators that come from Iris. This is needed because the tests in this repository will be ran by future versions of Iris and changes there can break the tests while the extensions are actually working.