### PR TITLE
Refactor e2e tests to use dynamic items

### DIFF
--- a/tests/e2e/app-elements/item-details.map.ts
+++ b/tests/e2e/app-elements/item-details.map.ts
@@ -5,7 +5,7 @@ const defaultFieldLocator = ".-sf-short-text-default";
 
 export class ItemDetailsMap {
     public static ExtendedTitleField: ElementFinder = element(by.css(".custom-title-input"));
-    public static EditorInternalField: ElementFinder = element.all(by.cssContainingText("div", ITEM_CONTENT_BEGINNING)).first();
+    public static EditorInternalField: ElementFinder = element.all(by.css("sf-editor .sf-editor")).first();
     public static HtmlFieldExpandButton: ElementFinder = element(by.css("a[title=Expand]"));
     public static TitleField: ElementFinder = element(by.css(defaultFieldLocator));
     public static TitleInput: ElementFinder = ItemDetailsMap.TitleField.element(by.css("input"));

--- a/tests/e2e/app-specs/verify-extensions.e2e-spec.ts
+++ b/tests/e2e/app-specs/verify-extensions.e2e-spec.ts
@@ -20,16 +20,21 @@ import {
     PAGES_URL,
     NEWS_TYPE_NAME,
     PAGES_TYPE_NAME,
-    BASE_URL
+    CONTENT_PAGE_URL
 } from "../helpers/constants";
 import { PrintPreview } from "../app-elements/print-preview.component";
 import { ItemDetails } from "../app-elements/item-details.component";
 import { VideosModal } from "../app-elements/videos-modal.component";
 import { Theme } from "../app-elements/theme.component";
 import { ItemListMap } from "../app-elements/item-list.map";
-import dynamicModuleOperations from '../setup/dynamic-module-operations';
-import { generateModuleMock } from '../setup/module-mock';
-import { setTypeNamePlural } from '../helpers/set-typename-plural';
+import dynamicModuleOperations from "../setup/dynamic-module-operations";
+import { generateModuleMock, generateDynamicItemMock } from "../setup/module-mock";
+import { setTypeNamePlural } from "../helpers/set-typename-plural";
+
+const dynamicModuleMock = generateModuleMock();
+const dynamicTypeName = setTypeNamePlural(dynamicModuleMock.ContentTypeItemTitle).toLowerCase();
+const dynamicItemMock = generateDynamicItemMock(dynamicTypeName, "Some item");
+let moduleId: string;
 
 const ENTITY_MAP = new Map<string, any>()
     .set(NEWS_TYPE_NAME, {
@@ -39,16 +44,17 @@ const ENTITY_MAP = new Map<string, any>()
     .set(PAGES_TYPE_NAME, {
         url: PAGES_URL,
         title: "Home"
+    })
+    .set(dynamicTypeName, {
+        url: `${CONTENT_PAGE_URL}${dynamicTypeName}`,
+        title: dynamicItemMock.data.Title
     });
-
-const dynamicModuleMock = generateModuleMock();
-const dynamicItemTitlePlural = setTypeNamePlural(dynamicModuleMock.ContentTypeItemTitle).toLowerCase();
-let moduleId: string;
 
 describe("Verify extensions", () => {
     beforeAll(async (done: DoneFn) => {
         await initAuth(USERNAME, PASSWORD);
         moduleId = await dynamicModuleOperations.initiateDynamicModule(dynamicModuleMock);
+        await dynamicModuleOperations.createDynamicModuleItem(dynamicItemMock);
         done();
     }, TIMEOUT);
 
@@ -80,31 +86,27 @@ describe("Verify extensions", () => {
         // TODO: Add item hooks test for pages when create edit screens are available
     });
 
-    const entity = NEWS_TYPE_NAME;
-    const url = ENTITY_MAP.get(entity).url;
-    const itemToVerify = ENTITY_MAP.get(entity).title;
-
-    it(`custom title field [${entity}]`, async () => {
-        await BrowserNavigate(url);
-        await ItemList.ClickOnItem(itemToVerify);
+    it(`custom title field [${NEWS_TYPE_NAME}]`, async () => {
+        await BrowserNavigate(ENTITY_MAP.get(NEWS_TYPE_NAME).url);
+        await ItemList.ClickOnItem(ENTITY_MAP.get(NEWS_TYPE_NAME).title);
         await ItemDetails.VerifyCustomTitleField();
         await ItemDetails.ClickBackButton(true);
     });
 
-    it(`word count editor toolbar button [${entity}]`, async () => {
-        await BrowserNavigate(url);
-        await ItemList.ClickOnItem(itemToVerify);
-        await ItemDetails.ExpandHtmlField();
+    it(`word count editor toolbar button [${dynamicTypeName}]`, async () => {
+        await BrowserNavigate(ENTITY_MAP.get(dynamicTypeName).url);
+        await ItemList.ClickOnItem(ENTITY_MAP.get(dynamicTypeName).title);
+        await ItemDetails.FocusHtmlField();
         await SelectAllAndTypeText(SAMPLE_TEXT_CONTENT);
         await ItemDetails.ClickToolbarButtonByTitle("Words count");
         await ItemDetails.VerifyHtmlToolbarWordCount();
         await ItemDetails.ClickBackButton(true);
     });
 
-    it(`embed video editor toolbar button [${entity}]`, async () => {
-        await BrowserNavigate(url);
-        await ItemList.ClickOnItem(itemToVerify);
-        await ItemDetails.ExpandHtmlField();
+    it(`embed video editor toolbar button [${dynamicTypeName}]`, async () => {
+        await BrowserNavigate(ENTITY_MAP.get(dynamicTypeName).url);
+        await ItemList.ClickOnItem(ENTITY_MAP.get(dynamicTypeName).title);
+        await ItemDetails.FocusHtmlField();
         await ItemDetails.ClickToolbarButtonByTitle("Sitefinity videos");
         await VideosModal.VerifyModalTitle();
         await VideosModal.CancelModal();
@@ -112,28 +114,28 @@ describe("Verify extensions", () => {
         await BrowserWaitForElement(ItemListMap.ImageColumn);
     });
 
-    it(`insert symbol [${entity}]`, async () => {
-        await BrowserNavigate(url);
-        await ItemList.ClickOnItem(itemToVerify);
-        await ItemDetails.ExpandHtmlField();
+    it(`insert symbol [${dynamicTypeName}]`, async () => {
+        await BrowserNavigate(ENTITY_MAP.get(dynamicTypeName).url);
+        await ItemList.ClickOnItem(ENTITY_MAP.get(dynamicTypeName).title);
+        await ItemDetails.FocusHtmlField();
         await ItemDetails.ClickToolbarButtonByTitle("Insert symbol");
         await ItemDetails.VerifyAndClickSymbolListButton();
         await ItemDetails.ClickBackButton(true);
     });
 
-    it(`applied theme [${entity}]`, async () => {
+    it(`applied theme [${dynamicTypeName}]`, async () => {
         await BrowserNavigate(THEME_URL);
         await Theme.SelectTheme("Sample");
         await Theme.UseSelectedTheme();
 
-        await BrowserNavigate(url);
+        await BrowserNavigate(ENTITY_MAP.get(dynamicTypeName).url);
         await ItemList.VerifyThemeButtonColor();
     });
 
-    xit(`spell checker [${entity}]`, async () => {
-        await BrowserNavigate(url);
-        await ItemList.ClickOnItem(itemToVerify);
-        await ItemDetails.ExpandHtmlField();
+    xit(`spell checker [${dynamicTypeName}]`, async () => {
+        await BrowserNavigate(ENTITY_MAP.get(dynamicTypeName).url);
+        await ItemList.ClickOnItem(ENTITY_MAP.get(dynamicTypeName).title);
+        await ItemDetails.FocusHtmlField();
         await ItemDetails.ChangeEditorContent(SAMPLE_TEXT_WITH_SPELL_CHECK_SUGGESTIONS);
         await ItemDetails.FocusHtmlField();
         await ItemDetails.VerifyHtmlToolbarSpellCheck();
@@ -144,40 +146,25 @@ describe("Verify extensions", () => {
         await ItemDetails.VerifyEditorContent(SAMPLE_TEXT_AFTER_SPELL_CHECK_CORRECTIONS);
     });
 
-    it(`item hooks [${entity}]`, async () => {
+    it(`item hooks [${dynamicTypeName}]`, async () => {
         // verify create
-        await BrowserNavigate(url);
+        await BrowserNavigate(ENTITY_MAP.get(dynamicTypeName).url);
         await ItemList.ClickOnCreate();
         await ItemDetails.WaitForPublishButton();
         await BrowserVerifyConsoleOutput("new item");
         await ItemDetails.ClickBackButton();
 
         // verify edit
-        await ItemList.ClickOnItem(itemToVerify);
+        await ItemList.ClickOnItem(ENTITY_MAP.get(dynamicTypeName).title);
         await ItemDetails.WaitForPublishButton();
         await ItemDetails.FocusHtmlField(); // wait for fields to load
-        await BrowserVerifyConsoleOutput(itemToVerify);
+        await BrowserVerifyConsoleOutput(ENTITY_MAP.get(dynamicTypeName).title);
     });
 
-    it("custom array of guids field", async () => {
-        const dynamicModuleUrl = `${BASE_URL}content/${dynamicItemTitlePlural}`;
-        const dynamicItemTitle = "Some random title"
-        const dynamicItem = {
-            typeName: dynamicItemTitlePlural,
-            data: {
-                "Title": dynamicItemTitle,
-                "UrlName": "some-url",
-                "ArrayOfGuidsField": ["2c379b03-5427-44bb-8880-d3e8d16e83a5","00beeddf-1fff-43aa-8630-c3fd310d016c"]
-            }
-
-        };
-        const expectedValue = "2c379b03-5427-44bb-8880-d3e8d16e83a5,00beeddf-1fff-43aa-8630-c3fd310d016c";
-
-        await dynamicModuleOperations.createDynamicModuleItem(dynamicItem);
-
-        await BrowserNavigate(dynamicModuleUrl);
-        await ItemList.ClickOnItem(dynamicItemTitle);
-        await ItemDetails.VerifyCustomArrayOfGUIDsField(expectedValue);
+    it(`custom array of guids field [${dynamicTypeName}]`, async () => {
+        await BrowserNavigate(ENTITY_MAP.get(dynamicTypeName).url);
+        await ItemList.ClickOnItem(ENTITY_MAP.get(dynamicTypeName).title);
+        await ItemDetails.VerifyCustomArrayOfGUIDsField(dynamicItemMock.data.ArrayOfGuidsField.join(","));
         await ItemDetails.ClickBackButton(false);
     });
 });

--- a/tests/e2e/setup/module-mock.ts
+++ b/tests/e2e/setup/module-mock.ts
@@ -66,6 +66,49 @@ export function generateModuleMock() {
             "ClassificationId": "cb0f3a19-a211-48a7-88ec-77495c0f5374",
             "ColumnName": "",
             "DBLength": "",
+            "DBType": "CLOB",
+            "DecimalPlacesCount": 0,
+            "DefaultValue": "",
+            "FileExtensions": "",
+            "FileMaxSize": 0,
+            "ImageExtensions": "",
+            "ImageMaxSize": 0,
+            "IncludeInIndexes": false,
+            "InstructionalChoice": "- Select -",
+            "InstructionalText": "",
+            "IsHiddenField": false,
+            "IsRequired": false,
+            "IsRequiredToSelectCheckbox": false,
+            "IsRequiredToSelectDdlValue": false,
+            "LengthValidationMessage": "",
+            "MaxLength": 0,
+            "MediaType": "",
+            "MinLength": 0,
+            "Name": "Content",
+            "NumberUnit": "",
+            "RegularExpression": null,
+            "Title": "Content",
+            "TypeName": "LongText",
+            "TypeUIName": "Long text",
+            "VideoExtensions": "",
+            "VideoMaxSize": 0,
+            "WidgetTypeName": "Telerik.Sitefinity.Web.UI.Fields.HtmlField",
+            "IsLocalizable": true
+        },
+        {
+            "AllowImageLibrary": false,
+            "AllowMultipleFiles": false,
+            "AllowMultipleImages": false,
+            "AllowMultipleVideos": false,
+            "AllowNulls": false,
+            "CanCreateItemsWhileSelecting": true,
+            "CanSelectMultipleItems": true,
+            "CheckedByDefault": false,
+            "ChoiceRenderType": "",
+            "Choices": "",
+            "ClassificationId": "cb0f3a19-a211-48a7-88ec-77495c0f5374",
+            "ColumnName": "",
+            "DBLength": "",
             "DBType": null,
             "DecimalPlacesCount": 0,
             "DefaultValue": "",
@@ -106,4 +149,16 @@ export function generateModuleMock() {
         "IsSelfReferencing": false,
         "CheckFieldPermissions": false
     };
+}
+
+export function generateDynamicItemMock(typeName: string, itemTitle: string) {
+    return {
+        typeName,
+        data: {
+            "Title": itemTitle,
+            "UrlName": "some-url",
+            "Content": "<p>Hello everyone, this is a long text field</p>",
+            "ArrayOfGuidsField": ["2c379b03-5427-44bb-8880-d3e8d16e83a5", "00beeddf-1fff-43aa-8630-c3fd310d016c"]
+        }
+    }
 }


### PR DESCRIPTION
The purpose behind this change is e2e tests not to depend on hardcoded items and create everything they need in their setup. That way the transition to another sandbox (Quantum for example) will be much easier.