### PR TITLE
Fix switch text direction extension 

### DIFF
--- a/editor-extender/switch-text-direction/switch-text-direction.provider.ts
+++ b/editor-extender/switch-text-direction/switch-text-direction.provider.ts
@@ -65,7 +65,7 @@ class SwitchTextDirectionProvider implements EditorConfigProvider {
         };
 
         // Should group the direction buttons once the editor is loaded and focused.
-        fromEvent(editorHost.context, "focusin")
+        fromEvent(editorHost[0], "focusin")
             .pipe(first())
             .subscribe(() => {
                 const toolbar = editorHost.getKendoEditor().toolbar.element;
@@ -207,7 +207,7 @@ class SwitchTextDirectionProvider implements EditorConfigProvider {
      * @memberof SwitchTextDirectionProvider
      */
     private handleCursorMove(editorHost) {
-        const editorElement: HTMLElement = editorHost.context;
+        const editorElement: HTMLElement = editorHost[0];
         const toggleToolbarButtonsSelectedClasses = () => {
             let parent = this.findParent(editorHost);
 


### PR DESCRIPTION
context is removed from JQuery API:
https://api.jquery.com/context/