### PR TITLE
Add Implicit Wait for Kendo Popup

### DIFF
--- a/tests/e2e/app-elements/item-details.component.ts
+++ b/tests/e2e/app-elements/item-details.component.ts
@@ -137,10 +137,15 @@ export class ItemDetails {
         await BrowserWaitForElementHidden(ItemDetailsMap.EditorCustomEditMenu);
     }
 
-    static async ClickToolbarButtonByTitle(buttonTitle: string): Promise<void> {
+    static async ClickToolbarButtonByTitle(buttonTitle: string, waitForAnimation: boolean = false): Promise<void> {
         await BrowserWaitForElement(ItemDetailsMap.ToolbarButtonByTitle(buttonTitle));
         const toolbarButton = ItemDetailsMap.ToolbarButtonByTitle(buttonTitle);
         await toolbarButton.click();
+
+        if (waitForAnimation) {
+            // Implicit wait is needed because many of these buttons have kendo animations causing instability
+            await browser.sleep(1000);
+        }
     }
 
     static async VerifyAndClickSymbolListButton(): Promise<void> {

--- a/tests/e2e/app-specs/verify-extensions.e2e-spec.ts
+++ b/tests/e2e/app-specs/verify-extensions.e2e-spec.ts
@@ -124,7 +124,7 @@ describe("Verify extensions", () => {
         await BrowserNavigate(ENTITY_MAP.get(dynamicTypeName).url);
         await ItemList.ClickOnItem(ENTITY_MAP.get(dynamicTypeName).title);
         await ItemDetails.FocusHtmlField();
-        await ItemDetails.ClickToolbarButtonByTitle("Insert symbol");
+        await ItemDetails.ClickToolbarButtonByTitle("Insert symbol", true);
         await ItemDetails.VerifyAndClickSymbolListButton();
         await ItemDetails.ClickBackButton(true);
     });


### PR DESCRIPTION
The Kendo popup is causing some instability in the tests because of the animation when appearing on the page